### PR TITLE
Linear v4: added tabular random walk chain env, bug fixes

### DIFF
--- a/linear/algos/sf_return_ag.py
+++ b/linear/algos/sf_return_ag.py
@@ -132,7 +132,7 @@ class SFReturnAgent(BaseLinearAgent):
         cur_act = self.traj['a'][t_idx]
 
         # Compute successor lambda return
-        sl_G = self.compute_Q_value(cur_phi, cur_act)
+        sl_G = self.compute_successor_return(cur_phi, cur_act)
 
         sl_err = (sl_G - (cur_phi @ self.Wv))
         d_Wv = sl_err * cur_phi
@@ -143,10 +143,10 @@ class SFReturnAgent(BaseLinearAgent):
         # (Log) Value function error
         self.log_dict['value_errors'].append(sl_err)
 
-    def compute_Q_value(self, phi, act) -> float:
+    def compute_successor_return(self, phi, act) -> float:
         """
-        Helper function, compute the value given a state feature and action
-
+        Helper function, compute the value estimate using the lambda
+        successor feature return
         :param phi: state feature
         :param act: action
         :return: value, Q(phi, act)
@@ -154,6 +154,16 @@ class SFReturnAgent(BaseLinearAgent):
         cur_sf = self.Ws[act] @ phi  # (d, )
         sl_G = cur_sf @ (self.Wr + (self.gamma * (1.0 - self.lamb) * self.Wv))  # scalar
         return sl_G
+
+    def compute_Q_value(self, phi, act) -> float:
+        """
+        Helper function, compute the value given a state feature and action
+        using just the value function parameters
+        NOTE: using Q for compatibility but it should be V function
+
+        :return: value, Q(phi, act)
+        """
+        return np.dot(phi, self.Wv)
 
     def _select_action(self, phi) -> int:
         # TODO: change this for control (set policy here)

--- a/linear/default_config.ini
+++ b/linear/default_config.ini
@@ -4,7 +4,7 @@
 # ============================================================================
 
 [Training]
-num_episodes = 500
+num_episodes = 1000
 
 # cs_seed = 2,4,6,8,10,12,14,16,18,20,22,24,26,28,30,32,34,36,38,40,42,44,46,48,50,52,54,56,58,60
 cs_seed = 2
@@ -12,7 +12,8 @@ cs_seed = 2
 
 [Env]
 # Class name string, used to grab the class (if imported)
-cls_string = BoyansChainEnv
+# cls_string = BoyansChainEnv
+cls_string = RandomWalkChainEnv
 
 [Agent]
 # Class name string, used to grab the class (if imported)
@@ -24,9 +25,9 @@ cs_gamma = 1.0
 
 # Agent learning settings
 # cs_lamb = 0.2, 0.3, 0.5, 0.8, 1.0
-cs_lamb = 0.0
+cs_lamb = 0.7
 # cs_lr = 0.02, 0.1
-cs_lr = 0.005
+cs_lr = 0.05
 
 # Give the agent the best-fit reward function parameters
 use_true_R_fn = False

--- a/linear/envs/random_walk_chain.py
+++ b/linear/envs/random_walk_chain.py
@@ -1,0 +1,213 @@
+# ============================================================================
+# Random walk chain experiment, adopted from Sutton & Barto Book
+#
+# Author: Anthony G. Chen
+# ============================================================================
+
+import gym
+import numpy as np
+
+
+class RandomWalkChainEnv(gym.Env):
+    """
+    Description:
+
+    State space:
+
+    Action:
+    """
+
+    def __init__(self, seed=0):
+        self.n_states = 20  # NOTE fix for now and set to 20 for 19-state chain
+        self.feature_dim = self.n_states-1  # NOTE: using tabular representation
+
+        # ==
+        # Initialize spaces
+        self.action_space = gym.spaces.Discrete(n=1)
+        self.observation_space = gym.spaces.Box(
+            low=np.zeros(self.feature_dim),
+            high=np.ones(self.feature_dim),
+            dtype=np.float
+        )
+
+        self.rng = np.random.default_rng(seed)
+        self.state = int(self.n_states / 2)  # start in middle
+
+    def step(self, action):
+        """
+        Transition in the random walk chain
+        :return:
+        """
+        # ==
+        # Update state
+        reward = 0.0
+        done = False
+
+        # Transition
+        if 1 <= self.state < self.n_states:
+            cur_trans = self.rng.choice([-1, +1])
+            self.state = self.state + cur_trans
+
+        # Features, rewards and termination
+        phi = self.state_2_features(self.state)
+        if self.state == self.n_states:
+            reward = 1.0
+        if not (1 <= self.state < self.n_states):
+            done = True
+
+        return phi, reward, done, {}
+
+    def state_2_features(self, state):
+        """
+        Calculate the feature vector from a given state number
+        :param state: integer index
+        :return: feature vector
+        """
+        # Simple tabular features
+        phi = np.zeros((self.feature_dim,),
+                       dtype=np.float)
+
+        # Set index
+        s_idx = state - 1
+        if 0 <= s_idx < self.feature_dim:
+            phi[s_idx] = 1.0
+
+        return phi
+
+    def reset(self):
+        self.state = int(self.n_states / 2)  # start in middle
+
+        phi = self.state_2_features(self.state)
+        return phi
+
+    def get_num_states(self):
+        """
+        Helper function to get the number of underlying states in this env
+        NOTE: +1 to include the termination state
+        :return: int of number of states
+        """
+        return self.n_states + 1
+
+    def get_transition_matrix(self):
+        """
+        Helper function to return the transition matrix for this env
+        :return: (self.n_states+1, self.n_states+1) np matrix
+        """
+        # Transition matrix
+        p_n_states = self.n_states + 1
+        P_trans = np.zeros((p_n_states, p_n_states))
+        for i in range(1, (p_n_states-1)):
+            P_trans[i, i + 1] = 0.5
+            P_trans[i, i - 1] = 0.5
+        P_trans[0, 0] = 0.0
+        P_trans[self.n_states, self.n_states] = 0.0
+
+        return P_trans
+
+    def get_reward_function(self):
+        """
+        Helper function to get the (tabular) reward function for each state
+        NOTE: charactering each state's reward by the expected reward
+              from transitioning out of the state. This may be slightly
+              different from the TD way of solving for state values.
+        :return: (self.n_states+1,) vector
+        """
+        p_n_states = self.n_states + 1
+        R_fn = np.zeros(p_n_states)
+        R_fn[-1] = 1.0
+
+        return R_fn
+
+    def solve_linear_reward_parameters(self):
+        """
+        Helper function to solve for the best-fit linear parameters for the
+        reward function.
+        :return: (self.feature_dim, ) parameters for reward fn
+        """
+        p_n_states = self.n_states + 1
+
+        # Get feature matrix (p_n_states, feature_dim)
+        phi_mat = np.empty((p_n_states, self.feature_dim))
+        for s_n in range(p_n_states):
+            phi_mat[s_n] = self.state_2_features(s_n)
+
+        # Get reward function
+        r_vec = self.get_reward_function()
+
+        # Solve parameters from Moore–Penrose inverse
+        phi_mat_T = np.transpose(phi_mat)
+        mp_inv = np.linalg.inv((phi_mat_T @ phi_mat)) @ phi_mat_T
+        bf_Wr = mp_inv @ r_vec
+
+        return bf_Wr
+
+    def render(self):
+        pass
+
+    def close(self):
+        pass
+
+
+if __name__ == '__main__':
+
+
+    # FOR TESTING ONLY
+    print('hello')
+
+    seed = np.random.randint(100)
+    print('numpy seed:', seed)
+    # np.random.seed(seed)
+
+    # TODO add back stuff about env and running env?
+    env = RandomWalkChainEnv(seed=seed)
+
+    P = env.get_transition_matrix()
+    print('trans mat shape', np.shape(P))
+    # print(P)
+
+    R = env.get_reward_function()
+    print('rew function shape', np.shape(R))
+    # print(R)
+
+    # Solve for tabular value fn
+    n_states = env.get_num_states()
+    gamma = 1.0
+    c_mat = (np.identity(n_states) - (gamma * P))
+    sr_mat = np.linalg.inv(c_mat)
+    v_fn_tab = sr_mat @ R
+
+    np.set_printoptions(precision=3)
+
+    print('tabular SR', np.shape(sr_mat))
+    # print(sr_mat)
+    print('tabular value function:')
+    print(v_fn_tab)
+
+    # ==
+    # Run a few
+    print('=== set-up ===')
+    print('env', env)
+    print('action space', env.action_space)
+    print('obs space', env.observation_space)
+
+    print('=== start ===')
+    cur_obs = env.reset()
+    print(f's: {env.state}, obs: {cur_obs}')
+
+    for step in range(30):
+        action = env.action_space.sample()
+        cur_obs, reward, done, info = env.step(action)
+
+        print(f'a: {action}, s: {env.state}, obs: {cur_obs}, r:{reward}, d:{done}, {info}')
+
+
+
+
+
+
+
+
+
+
+
+

--- a/linear/train_linear_pred.py
+++ b/linear/train_linear_pred.py
@@ -145,8 +145,8 @@ def helper_extract_agent_log_dict(agent):
     return log_dict
 
 
-def run_single_boyans_chain(exp_kwargs: dict,
-                            args, logger=None):
+def run_single_lienar_experiment(exp_kwargs: dict,
+                                 args, logger=None):
     # ==================================================
     # Initialize environment
     envCls = exp_kwargs['envCls']
@@ -308,7 +308,7 @@ def run_experiments(args, config: configparser.ConfigParser, logger=None):
     for attri_tup in attri_iterable:
         exp_kwargs = {indep_vars_keys[i]: attri_tup[i]
                       for i in range(len(attri_tup))}
-        run_single_boyans_chain(exp_kwargs, args, logger=logger)
+        run_single_lienar_experiment(exp_kwargs, args, logger=logger)
 
 
 if __name__ == "__main__":

--- a/linear/train_linear_pred.py
+++ b/linear/train_linear_pred.py
@@ -18,6 +18,7 @@ from tqdm import tqdm
 from algos.sf_return_ag import SFReturnAgent
 from algos.td_lambda_ag import SarsaLambdaAgent
 from envs.boyans_chain import BoyansChainEnv
+from envs.random_walk_chain import RandomWalkChainEnv
 
 # Things to log
 LogTupStruct = namedtuple('Log', field_names=['num_episodes',  # experiment-specific
@@ -32,6 +33,7 @@ LogTupStruct = namedtuple('Log', field_names=['num_episodes',  # experiment-spec
                                               'total_steps',
                                               'cumulative_reward',
                                               'v_fn_rmse',
+                                              'sf_G_rmse',
                                               'value_loss_avg',  # agent log dict specific logs
                                               'reward_loss_avg',
                                               'sf_loss_avg',
@@ -82,8 +84,8 @@ def solve_value_fn(env, gamma):
 
 def compute_value_rmse(env, agent, true_v_fn):
     """
-    Compute the RMSE for the value function of a given agent.
-    Here hard-coded for the 14-state Boyan's chain.
+    Compute the RMSE for the value function of a given agent
+    and environment
 
     :return: scalar RMSE
     """
@@ -99,8 +101,25 @@ def compute_value_rmse(env, agent, true_v_fn):
         # NOTE: assumes only a single action is available
         # TODO: make it into compute V function to marginalize over actions?
         esti_v_fn[s_n] = agent.compute_Q_value(s_phi, 0)
-        # esti_v_fn[s_n] = np.dot(s_phi, agent.Wv)  # TODO delete
 
+    return compute_rmse(esti_v_fn, true_v_fn)
+
+
+def compute_sf_ret_rmse(env, agent, true_v_fn):
+    """
+    Compute RMSE for the lambda successor return, if possible
+    :return: scalar RMSE
+    """
+    if not hasattr(agent, 'compute_successor_return'):
+        return None
+
+    n_states = env.get_num_states()
+    esti_v_fn = np.empty(n_states)
+    for s_n in range(n_states):
+        s_phi = env.state_2_features(s_n)  # state features
+        esti_v_fn[s_n] = agent.compute_successor_return(
+            s_phi, 0
+        )  # compute value
     return compute_rmse(esti_v_fn, true_v_fn)
 
 
@@ -217,6 +236,7 @@ def run_single_lienar_experiment(exp_kwargs: dict,
                 # ==
                 # Compute Value function RMSE
                 v_fn_rmse = compute_value_rmse(environment, agent, true_v_fn)
+                sf_G_rmse = compute_sf_ret_rmse(environment, agent, true_v_fn)
 
                 # ==
                 # Episode log items
@@ -226,6 +246,7 @@ def run_single_lienar_experiment(exp_kwargs: dict,
                 epis_log_dict['total_steps'] = steps
                 epis_log_dict['cumulative_reward'] = cumulative_reward
                 epis_log_dict['v_fn_rmse'] = v_fn_rmse
+                epis_log_dict['sf_G_rmse'] = sf_G_rmse
 
                 # ==
                 # Compute losses from the agent logs
@@ -246,6 +267,9 @@ def run_single_lienar_experiment(exp_kwargs: dict,
                 # ==
                 # Terminate
                 break
+
+    # np.set_printoptions(precision=3)  # TODO delete below
+    # print(agent.Ws)
 
     # Maybe: save the SR matrix?
 


### PR DESCRIPTION
Added the 19-state random walk environment with tabular (i.e. one-hot)  features.
Bug fixes: for TD-style learning (value function and successor feature) fixed bug where the last state is not taken into consideration in episodic settings.
Better logging: for the `SFReturnAgent`, I can now log both the value function (`self.Wv`) value estimate and the successor lambda return value estimates separately during training.