### PR TITLE
Linear v8: LSF value parameter elig trace, logging SF matrix error

### DIFF
--- a/linear/default_config.ini
+++ b/linear/default_config.ini
@@ -4,7 +4,7 @@
 # ============================================================================
 
 [Training]
-num_episodes = 1000
+num_episodes = 100
 
 # cs_seed = 2,4,6,8,10,12,14,16,18,20,22,24,26,28,30,32,34,36,38,40,42,44,46,48,50,52,54,56,58,60
 cs_seed = 2
@@ -14,20 +14,25 @@ cs_seed = 2
 # Class name string, used to grab the class (if imported)
 # cls_string = BoyansChainEnv
 cls_string = RandomWalkChainEnv
+#cls_string = RandomWalkChainEnv, BoyansChainEnv
+#cls_string = PerfBinaryTreeEnv
 
 [Agent]
 # Class name string, used to grab the class (if imported)
 cls_string = SFReturnAgent
-# cls_string = SarsaLambdaAgent
+#cls_string = SarsaLambdaAgent
+#cls_string = ExpectedTraceAgent
+#cls_string = SarsaLambdaAgent, SFReturnAgent
 
 # MDP setting
 cs_gamma = 1.0
 
 # Agent learning settings
-# cs_lamb = 0.2, 0.3, 0.5, 0.8, 1.0
-cs_lamb = 0.7
-# cs_lr = 0.02, 0.1
-cs_lr = 0.05
+# cs_lamb = 0.0, 0.1, 0.2, 0.3, 0.5, 0.8, 0.9, 0.95, 1.0
+cs_lamb = 0.6
+cs_eta_trace = 0.6
+# cs_lr = 0.02, 0.06, 0.1, 0.2
+cs_lr = 0.06
 
 # Give the agent the best-fit reward function parameters
 use_true_R_fn = False

--- a/linear/default_config.ini
+++ b/linear/default_config.ini
@@ -13,23 +13,24 @@ cs_seed = 2
 [Env]
 # Class name string, used to grab the class (if imported)
 # cls_string = BoyansChainEnv
-cls_string = RandomWalkChainEnv
+# cls_string = RandomWalkChainEnv
 #cls_string = RandomWalkChainEnv, BoyansChainEnv
-#cls_string = PerfBinaryTreeEnv
+cls_string = PerfBinaryTreeEnv
 
 [Agent]
 # Class name string, used to grab the class (if imported)
-cls_string = SFReturnAgent
+#cls_string = SFReturnAgent
 #cls_string = SarsaLambdaAgent
 #cls_string = ExpectedTraceAgent
-#cls_string = SarsaLambdaAgent, SFReturnAgent
+cls_string = SarsaLambdaAgent, SFReturnAgent
 
 # MDP setting
 cs_gamma = 1.0
 
 # Agent learning settings
 # cs_lamb = 0.0, 0.1, 0.2, 0.3, 0.5, 0.8, 0.9, 0.95, 1.0
-cs_lamb = 0.6
+cs_lamb = 0.8
+#cs_eta_trace = 0.0, 0.6, 0.9
 cs_eta_trace = 0.6
 # cs_lr = 0.02, 0.06, 0.1, 0.2
 cs_lr = 0.06

--- a/linear/envs/perf_bin_tree.py
+++ b/linear/envs/perf_bin_tree.py
@@ -166,7 +166,7 @@ class PerfBinaryTreeEnv(gym.Env):
     def get_feature_matrix(self):
         """
         Helper function to get the state to features mapping matrix
-        :return: (self.n_states+1, self.feature_dim) np matrix
+        :return: (self.n_states, self.feature_dim) np matrix
         """
         phi_mat = np.empty((self.n_states, self.feature_dim))
         for s_idx in range(self.n_states):

--- a/linear/train_linear_pred.py
+++ b/linear/train_linear_pred.py
@@ -223,7 +223,7 @@ def helper_extract_agent_log_dict(agent):
     return log_dict
 
 
-def run_single_lienar_experiment(exp_kwargs: dict,
+def run_single_linear_experiment(exp_kwargs: dict,
                                  args, logger=None):
     # ==================================================
     # Initialize environment
@@ -386,7 +386,7 @@ def run_experiments(args, config: configparser.ConfigParser, logger=None):
     for attri_tup in attri_iterable:
         exp_kwargs = {indep_vars_keys[i]: attri_tup[i]
                       for i in range(len(attri_tup))}
-        run_single_lienar_experiment(exp_kwargs, args, logger=logger)
+        run_single_linear_experiment(exp_kwargs, args, logger=logger)
 
 
 if __name__ == "__main__":

--- a/linear/utils/mdp_utils.py
+++ b/linear/utils/mdp_utils.py
@@ -120,15 +120,28 @@ def evaluate_sf_ret_rmse(env, agent, true_v_fn) -> float:
     return compute_rmse(esti_v_fn, true_v_fn)
 
 
-def evaluate_sf_rmse(env, agent, true_sf_fn) -> float:
+def evaluate_sf_mat_rmse(env, agent, true_sf_mat) -> float:
     """
-    Compute the RMSE for the successor feature if possible
+    Compute the RMSE for the successor feature matrix
     :param env:
     :param agent:
-    :param true_sf:
+    :param true_sf_mat:  (N, d) true successor feature matrix
     :return:
     """
-    pass
+    n_states = env.get_num_states()
+    d_features = env.observation_space.shape[0]
+    esti_sf_mat = np.empty((n_states, d_features))
+
+    for s_n in range(n_states):
+        # Get state features
+        s_phi = env.state_2_features(s_n)
+
+        # Compute the estimate SF
+        # TODO: hacky, assumes only single action is available, should fix
+        sf_T = s_phi.T @ agent.Ws[0]  # (d, )
+        esti_sf_mat[s_n] = sf_T
+
+    return compute_rmse(esti_sf_mat, true_sf_mat)
 
 
 if __name__ == "__main__":

--- a/linear/utils/mdp_utils.py
+++ b/linear/utils/mdp_utils.py
@@ -21,7 +21,7 @@ def compute_rmse(vec_a, vec_b) -> float:
 
 def solve_value_fn(env: gym.Env, gamma: float) -> np.ndarray:
     """
-    Solve the value functio for each state in an environment
+    Solve the value function for each state in an environment
     :param env: gym environment
     :param gamma: discount factor
     :return:
@@ -40,9 +40,30 @@ def solve_value_fn(env: gym.Env, gamma: float) -> np.ndarray:
     return v_fn
 
 
-def solve_linear_sf(env: gym.Env, discount_factor: float) -> np.ndarray:
+def solve_successor_feature(env: gym.Env, gamma: float) -> np.ndarray:
+    """
+    Analytically solve for the successor feature
+    :param env: gym environment
+    :param gamma: discount factor
+    :return: (N, d) numpy matrix of successor feature for each state
+    """
+    # Transition matrix
+    n_states = env.get_num_states()
+    P_trans = env.get_transition_matrix()
+
+    # Feature matrix
+    Phi_mat = env.get_feature_matrix()
+
+    # Solve and return
+    c_mat = (np.identity(n_states) - (gamma * P_trans))
+    sf_mat = np.linalg.inv(c_mat) @ Phi_mat
+    return sf_mat
+
+
+def solve_linear_sf_param(env: gym.Env, discount_factor: float) -> np.ndarray:
     """
     Solve for the linear successor features given an environment
+    TODO NOTE this is deprecated. Not sure if correct.
     :param env: gym environment
     :param discount_factor: (gamma * lamb)
     :return:
@@ -59,7 +80,7 @@ def solve_linear_sf(env: gym.Env, discount_factor: float) -> np.ndarray:
     return Z
 
 
-def compute_value_rmse(env: gym.Env, agent, true_v_fn) -> float:
+def evaluate_value_rmse(env: gym.Env, agent, true_v_fn) -> float:
     """
     Compute the RMSE for the value function of a given agent
     and environment
@@ -67,7 +88,6 @@ def compute_value_rmse(env: gym.Env, agent, true_v_fn) -> float:
     :return: scalar RMSE
     """
     n_states = env.get_num_states()
-
     esti_v_fn = np.empty(n_states)
 
     for s_n in range(n_states):
@@ -82,7 +102,7 @@ def compute_value_rmse(env: gym.Env, agent, true_v_fn) -> float:
     return compute_rmse(esti_v_fn, true_v_fn)
 
 
-def compute_sf_ret_rmse(env, agent, true_v_fn) -> float:
+def evaluate_sf_ret_rmse(env, agent, true_v_fn) -> float:
     """
     Compute RMSE for the lambda successor return, if possible
     :return: scalar RMSE
@@ -98,6 +118,17 @@ def compute_sf_ret_rmse(env, agent, true_v_fn) -> float:
             s_phi, 0
         )  # compute value
     return compute_rmse(esti_v_fn, true_v_fn)
+
+
+def evaluate_sf_rmse(env, agent, true_sf_fn) -> float:
+    """
+    Compute the RMSE for the successor feature if possible
+    :param env:
+    :param agent:
+    :param true_sf:
+    :return:
+    """
+    pass
 
 
 if __name__ == "__main__":

--- a/linear/utils/mdp_utils.py
+++ b/linear/utils/mdp_utils.py
@@ -1,0 +1,104 @@
+# =============================================================================
+# Utility functions for solving MDPs
+#
+# Author: Anthony G. Chen
+# =============================================================================
+
+import gym
+import numpy as np
+
+
+def compute_rmse(vec_a, vec_b) -> float:
+    """
+    Compute the root mean square error (RMSE) between two vectors
+    :param vec_a: np array of shape (N, )
+    :param vec_b: np array of shape (N, )
+    :return: scalar
+    """
+    sq_err = (vec_a - vec_b) ** 2
+    return np.sqrt(np.mean(sq_err))
+
+
+def solve_value_fn(env: gym.Env, gamma: float) -> np.ndarray:
+    """
+    Solve the value functio for each state in an environment
+    :param env: gym environment
+    :param gamma: discount factor
+    :return:
+    """
+    # Transition matrix
+    n_states = env.get_num_states()
+    P_trans = env.get_transition_matrix()
+
+    # Reward function
+    R_fn = env.get_reward_function()
+
+    # Solve and return
+    c_mat = (np.identity(n_states) - (gamma * P_trans))
+    v_fn = np.linalg.inv(c_mat) @ R_fn
+
+    return v_fn
+
+
+def solve_linear_sf(env: gym.Env, discount_factor: float) -> np.ndarray:
+    """
+    Solve for the linear successor features given an environment
+    :param env: gym environment
+    :param discount_factor: (gamma * lamb)
+    :return:
+    """
+    phiMat = env.get_feature_matrix()
+    transMat = env.get_transition_matrix()
+    p_n_states = np.shape(transMat)[0]
+
+    cMat = np.identity(p_n_states) - (discount_factor * transMat)
+    qMat = cMat @ phiMat
+
+    # Solve
+    Z = np.linalg.inv(qMat.T @ qMat) @ qMat.T @ transMat @ phiMat
+    return Z
+
+
+def compute_value_rmse(env: gym.Env, agent, true_v_fn) -> float:
+    """
+    Compute the RMSE for the value function of a given agent
+    and environment
+
+    :return: scalar RMSE
+    """
+    n_states = env.get_num_states()
+
+    esti_v_fn = np.empty(n_states)
+
+    for s_n in range(n_states):
+        # Get state features
+        s_phi = env.state_2_features(s_n)
+
+        # Compute the value estimate TODO change this
+        # NOTE: assumes only a single action is available
+        # TODO: make it into compute V function to marginalize over actions?
+        esti_v_fn[s_n] = agent.compute_Q_value(s_phi, 0)
+
+    return compute_rmse(esti_v_fn, true_v_fn)
+
+
+def compute_sf_ret_rmse(env, agent, true_v_fn) -> float:
+    """
+    Compute RMSE for the lambda successor return, if possible
+    :return: scalar RMSE
+    """
+    if not hasattr(agent, 'compute_successor_return'):
+        return None
+
+    n_states = env.get_num_states()
+    esti_v_fn = np.empty(n_states)
+    for s_n in range(n_states):
+        s_phi = env.state_2_features(s_n)  # state features
+        esti_v_fn[s_n] = agent.compute_successor_return(
+            s_phi, 0
+        )  # compute value
+    return compute_rmse(esti_v_fn, true_v_fn)
+
+
+if __name__ == "__main__":
+    print('hello world')


### PR DESCRIPTION
Added a `eta_trace` parameter to the `SFReturnAgent`, which is the eligibility trace decay parameter for the value function (parameter `self.Wv`)

Logging the error of the successor matrix approximation. Also added a `mdp_utils` class containing methods that help solve for the value function, successor matrix, etc.