### PR TITLE
Linear v10: ability to use solved SF and reward params, bug fixes

### DIFF
--- a/linear/algos/sf_return_ag.py
+++ b/linear/algos/sf_return_ag.py
@@ -55,8 +55,9 @@ class SFReturnAgent(BaseLinearAgent):
         ws_idxs = np.arange(self.feature_dim)
         self.Ws[:, ws_idxs, ws_idxs] = 1.0
 
-        # (Optional?) Give agent the optimal reward parameters
-        self.use_true_R_fn = use_true_reward_params  # TODO change attribute name to be identical to input arg
+        # (Optional) Give agent the solved sf and/or reward parameters
+        self.use_true_sf_params = use_true_sf_params
+        self.use_true_reward_params = use_true_reward_params
 
     def begin_episode(self, phi):
         super().begin_episode(phi)
@@ -84,11 +85,11 @@ class SFReturnAgent(BaseLinearAgent):
         # Learning
 
         # Reward learning
-        if (not self.use_true_R_fn) and (len(self.traj['r']) > 0):
+        if (not self.use_true_reward_params) and (len(self.traj['r']) > 0):
             self._optimize_reward_fn()
 
         # SF learning
-        if len(self.traj['r']) > 0:
+        if (not self.use_true_sf_params) and (len(self.traj['r']) > 0):
             self._optimize_successor_features(done)
 
         # Value learning

--- a/linear/algos/sf_return_ag.py
+++ b/linear/algos/sf_return_ag.py
@@ -20,6 +20,8 @@ class SFReturnAgent(BaseLinearAgent):
                  lamb=0.8,
                  eta_trace=0.0,
                  lr=0.1,
+                 use_true_reward_params=False,
+                 use_true_sf_params=False,
                  seed=0):
         """
         TODO define arguments
@@ -54,7 +56,7 @@ class SFReturnAgent(BaseLinearAgent):
         self.Ws[:, ws_idxs, ws_idxs] = 1.0
 
         # (Optional?) Give agent the optimal reward parameters
-        self.use_true_R_fn = False
+        self.use_true_R_fn = use_true_reward_params  # TODO change attribute name to be identical to input arg
 
     def begin_episode(self, phi):
         super().begin_episode(phi)

--- a/linear/envs/random_walk_chain.py
+++ b/linear/envs/random_walk_chain.py
@@ -83,75 +83,51 @@ class RandomWalkChainEnv(gym.Env):
     def get_num_states(self):
         """
         Helper function to get the number of underlying states in this env
-        NOTE: +1 to include the termination state
+        NOTE: -1 to exclude terminal states
         :return: int of number of states
         """
-        return self.n_states + 1
+        return self.n_states - 1
 
     def get_transition_matrix(self):
         """
-        Helper function to return the transition matrix for this env
-        :return: (self.n_states+1, self.n_states+1) np matrix
+        Helper function to return the transition matrix for this env,
+        excluding terminal states
+        :return: (self.n_states-1, self.n_states-1) np matrix
         """
         # Transition matrix
-        p_n_states = self.n_states + 1
+        p_n_states = self.n_states - 1
         P_trans = np.zeros((p_n_states, p_n_states))
         for i in range(1, (p_n_states-1)):
             P_trans[i, i + 1] = 0.5
             P_trans[i, i - 1] = 0.5
-        P_trans[0, 0] = 0.0
-        P_trans[self.n_states, self.n_states] = 0.0
+        P_trans[0, 1] = 0.5
+        P_trans[p_n_states-1, p_n_states-2] = 0.5
 
         return P_trans
 
     def get_reward_function(self):
         """
         Helper function to get the (tabular) reward function for each state
-        NOTE: charactering each state's reward by the expected reward
-              from transitioning out of the state. This may be slightly
-              different from the TD way of solving for state values.
-        :return: (self.n_states+1,) vector
+        NOTE: each state's reward is set to the _expected_ reward received
+              from transitioning _out_ of the state.
+        :return: (self.n_states-1,) vector
         """
-        p_n_states = self.n_states + 1
+        p_n_states = self.n_states - 1
         R_fn = np.zeros(p_n_states)
-        R_fn[-1] = 1.0
+        # .5 chance of transitioning left (reward = 0), .5 chance of
+        # terminating via transitioning right (reward = 1)
+        R_fn[-1] = 0.5
 
         return R_fn
 
     def get_feature_matrix(self):
         """
         Helper function to get the state to features mapping matrix
-        :return: (self.n_states+1, self.feature_dim) np matrix
+        :return: (self.n_states-1, self.feature_dim) np matrix
         """
-        # Get feature matrix (p_n_states, feature_dim)
-        p_n_states = self.n_states + 1
-        phi_mat = np.empty((p_n_states, self.feature_dim))
-        for s_n in range(p_n_states):
-            phi_mat[s_n] = self.state_2_features(s_n)
-        return phi_mat
-
-    def solve_linear_reward_parameters(self):
-        """
-        Helper function to solve for the best-fit linear parameters for the
-        reward function.
-        :return: (self.feature_dim, ) parameters for reward fn
-        """
-        p_n_states = self.n_states + 1
-
-        # Get feature matrix (p_n_states, feature_dim)
-        phi_mat = np.empty((p_n_states, self.feature_dim))
-        for s_n in range(p_n_states):
-            phi_mat[s_n] = self.state_2_features(s_n)
-
-        # Get reward function
-        r_vec = self.get_reward_function()
-
-        # Solve parameters from Moore–Penrose inverse
-        phi_mat_T = np.transpose(phi_mat)
-        mp_inv = np.linalg.inv((phi_mat_T @ phi_mat)) @ phi_mat_T
-        bf_Wr = mp_inv @ r_vec
-
-        return bf_Wr
+        # Tabular features
+        p_n_states = self.n_states - 1
+        return np.identity(p_n_states)
 
     def render(self):
         pass

--- a/linear/train_linear_prediction.py
+++ b/linear/train_linear_prediction.py
@@ -103,7 +103,21 @@ def _initialize_agent(cfg: DictConfig, environment) -> object:
     # ==
     # (Optional) Initialize true reward and SF functions
 
-    # TODO: optionally initiaze the true reward and SF functions
+    # Initialize solved SF parameters
+    if hasattr(cfg.agent.kwargs, 'use_true_sf_params'):
+        if cfg.agent.kwargs.use_true_sf_params:
+            linear_sf_param = mut.solve_linear_sf_param(
+                env=environment,
+                gamma=(cfg.agent.kwargs.gamma * cfg.agent.kwargs.lamb)
+            )
+            agent.Ws[0] = linear_sf_param
+    # Initialize solved reward parameters
+    if hasattr(cfg.agent.kwargs, 'use_true_reward_params'):
+        if cfg.agent.kwargs.use_true_reward_params:
+            linear_reward_param = mut.solve_linear_reward_param(
+                env=environment,
+            )
+            agent.Wr = linear_reward_param
 
     return agent
 
@@ -132,6 +146,7 @@ def _pre_compute(cfg: DictConfig, environment, agent) -> dict:
         'true_value_vec': true_v_fn,
         'true_sf_mat': true_sf_mat,
     }
+
     return out_dict
 
 
@@ -220,7 +235,6 @@ def write_post_episode_log(cfg: DictConfig,
     # ==
     # episode-specific logs
 
-    # TODO fix this how? (after dinner put the episode thing in a dict too
     log_dict['episode_idx'] = episode_dict['episode_idx']
     log_dict['total_steps'] = episode_dict['total_steps']
     log_dict['cumulative_reward'] = episode_dict['cumulative_reward']

--- a/linear/train_linear_prediction.py
+++ b/linear/train_linear_prediction.py
@@ -28,6 +28,7 @@ import utils.mdp_utils as mut
 class LogTupStruct:
     num_episodes: int = None
     envCls_name: str = None
+    env_kwargs: str = None
     agentCls_name: str = None
     seed: int = None
     gamma: float = None
@@ -206,6 +207,7 @@ def write_post_episode_log(cfg: DictConfig,
     log_dict = {
         'num_episodes': cfg.training.num_episodes,
         'envCls_name': cfg.env.cls_string,
+        'env_kwargs': str(cfg.env.kwargs),
         'agentCls_name': cfg.agent.cls_string,
         'seed': cfg.training.seed,  # global seed
         'lr': cfg.agent.lr,

--- a/linear/utils/mdp_utils.py
+++ b/linear/utils/mdp_utils.py
@@ -105,12 +105,14 @@ def evaluate_value_rmse(env: gym.Env, agent, true_v_fn) -> float:
 
     :return: scalar RMSE
     """
-    n_states = env.get_num_states()
+
+    phiMat = env.get_feature_matrix()  # (N, d) feature mat
+    n_states = np.shape(phiMat)[0]
     esti_v_fn = np.empty(n_states)
 
     for s_n in range(n_states):
         # Get state features
-        s_phi = env.state_2_features(s_n)
+        s_phi = phiMat[s_n, :]
 
         # Compute the value estimate TODO change this
         # NOTE: assumes only a single action is available
@@ -128,10 +130,12 @@ def evaluate_sf_ret_rmse(env, agent, true_v_fn) -> float:
     if not hasattr(agent, 'compute_successor_return'):
         return None
 
-    n_states = env.get_num_states()
+    phiMat = env.get_feature_matrix()  # (N, d) feature mat
+    n_states = np.shape(phiMat)[0]
     esti_v_fn = np.empty(n_states)
+
     for s_n in range(n_states):
-        s_phi = env.state_2_features(s_n)  # state features
+        s_phi = phiMat[s_n, :]  # state features
         esti_v_fn[s_n] = agent.compute_successor_return(
             s_phi, 0
         )  # compute value
@@ -146,7 +150,8 @@ def evaluate_sf_mat_rmse(env, agent, true_sf_mat) -> float:
     :param true_sf_mat:  (N, d) true successor feature matrix
     :return:
     """
-    # NOTE: assumes only single action, potentially fix TODO
+    # NOTE: assumes only single action, and assumes parameter name is Ws
+    #       potential TODO make more general
     sf_param = agent.Ws[0]  # (d, d)
     phiMat = env.get_feature_matrix()  # (N, d) feature mat
 

--- a/linear/utils/mdp_utils.py
+++ b/linear/utils/mdp_utils.py
@@ -82,6 +82,22 @@ def solve_linear_sf_param(env: gym.Env, gamma: float) -> np.ndarray:
     return Z
 
 
+def solve_linear_reward_param(env: gym.Env) -> np.ndarray:
+    """
+    Solve for the linear (one-step) reward parameter vector.
+    :param env:  gym environment
+    :return: (d, ) reward function parameters
+    """
+    phiMat = env.get_feature_matrix()  # (N, d) feature mat
+    rewVec = env.get_reward_function()  # (N, 1) reward vec
+
+    # Project and solve
+    solMat = np.linalg.inv((phiMat.T @ phiMat))
+    Wr = solMat @ phiMat.T @ rewVec
+
+    return Wr
+
+
 def evaluate_value_rmse(env: gym.Env, agent, true_v_fn) -> float:
     """
     Compute the RMSE for the value function of a given agent

--- a/linear/utils/mdp_utils.py
+++ b/linear/utils/mdp_utils.py
@@ -146,18 +146,11 @@ def evaluate_sf_mat_rmse(env, agent, true_sf_mat) -> float:
     :param true_sf_mat:  (N, d) true successor feature matrix
     :return:
     """
-    n_states = env.get_num_states()
-    d_features = env.observation_space.shape[0]
-    esti_sf_mat = np.empty((n_states, d_features))
+    # NOTE: assumes only single action, potentially fix TODO
+    sf_param = agent.Ws[0]  # (d, d)
+    phiMat = env.get_feature_matrix()  # (N, d) feature mat
 
-    for s_n in range(n_states):
-        # Get state features
-        s_phi = env.state_2_features(s_n)
-
-        # Compute the estimate SF
-        # TODO: hacky, assumes only single action is available, should fix
-        sf_T = s_phi.T @ agent.Ws[0]  # (d, )
-        esti_sf_mat[s_n] = sf_T
+    esti_sf_mat = phiMat @ sf_param
 
     return compute_rmse(esti_sf_mat, true_sf_mat)
 

--- a/linear/utils/mdp_utils.py
+++ b/linear/utils/mdp_utils.py
@@ -60,23 +60,25 @@ def solve_successor_feature(env: gym.Env, gamma: float) -> np.ndarray:
     return sf_mat
 
 
-def solve_linear_sf_param(env: gym.Env, discount_factor: float) -> np.ndarray:
+def solve_linear_sf_param(env: gym.Env, gamma: float) -> np.ndarray:
     """
-    Solve for the linear successor features given an environment
-    TODO NOTE this is deprecated. Not sure if correct.
+    Solve for the linear successor feature parameter matrix. Given an
+    environment, extract the transition and feature matrices. Solve the
+    best linear approximation to the perfect successor feature.
+
     :param env: gym environment
-    :param discount_factor: (gamma * lamb)
-    :return:
+    :param gamma: float discount factor
+    :return: np.array of (d, d) successor matrix
     """
-    phiMat = env.get_feature_matrix()
-    transMat = env.get_transition_matrix()
-    p_n_states = np.shape(transMat)[0]
+    phiMat = env.get_feature_matrix()  # (N, d) feature mat
+    transMat = env.get_transition_matrix()  # (N, N) trans mat
+    p_n_states = np.shape(transMat)[0]  # N
 
-    cMat = np.identity(p_n_states) - (discount_factor * transMat)
-    qMat = cMat @ phiMat
+    # Project and solve
+    cMat = np.identity(p_n_states) - (gamma * transMat)
+    proj_cMat = phiMat.T @ cMat @ phiMat
+    Z = np.linalg.inv(proj_cMat) @ (phiMat.T @ phiMat)
 
-    # Solve
-    Z = np.linalg.inv(qMat.T @ qMat) @ qMat.T @ transMat @ phiMat
     return Z
 
 


### PR DESCRIPTION
- Added ability to initialize an agent with linearly solved SF and/or reward parameters (for evaluating the agent's performance assuming one or both of these can be given)
- Various bug fixes for RMSE evaluation of the value function, SF value function and the SF matrix
- Updated the  `linear/envs/random_walk_chain.py` environment to ignore terminal states on the two ends when solving using feature and transition matrices (for eg the 19-state random chain will have just 19 states rather than 21)
