### PR TITLE
Linear v11: single file multirun, learning rate bug fix

### DIFF
--- a/linear/arg-job_train_hydra.script
+++ b/linear/arg-job_train_hydra.script
@@ -22,15 +22,21 @@ source $HOME/venvs/rlpyt/bin/activate
 # (2) no data to copy
 
 # (3) launch job with parameter sweeps
-python -u train_linear_prediction.py --multirun \
+#python -u train_linear_prediction.py --multirun \
+python -u train_linear_prediction.py \
+    hydra.run.dir=$sweep_parent_dir \
     hydra.sweep.dir=$sweep_parent_dir \
-    training.num_episodes=100 \
-    training.seed=2,4,6,8,10,12,14,16,18,20 \
-    env.cls_string=PerfBinaryTreeEnv \
-    agent.lr=0.001,0.01,0.03,0.06,0.1 \
+    training.num_episodes=1000 \
+    training.seed=[2,4,6,8,10,12,14,16,18,20] \
+    env.cls_string="PerfBinaryTreeEnv" \
+    +env.kwargs.depth=[3,5,7] \
+    agent=sf_return \
+    agent.kwargs.lr=[0.001,0.01,0.03,0.06,0.1] \
     agent.kwargs.gamma=0.9 \
-    agent.kwargs.lamb=0.0,0.3,0.5,0.7,0.9,0.95,0.99,1.0 \
-    agent.kwargs.eta_trace=0.0,0.3,0.5,0.7,0.9,0.95,0.99,1.0 \
+    agent.kwargs.lamb=[0.0,0.3,0.5,0.7,0.9,0.99,1.0] \
+    agent.kwargs.eta_trace=[0.0,0.3,0.5,0.7,0.9,0.99,1.0] \
+    agent.kwargs.use_true_sf_params=[True,False] \
+    agent.kwargs.use_true_reward_params=[True,False] \
 
 # (4) Copy things over to scratch?
 # cp $EXP_LOG_PATH /network/tmp1/chenant/tmp/

--- a/linear/conf/config.yaml
+++ b/linear/conf/config.yaml
@@ -15,6 +15,6 @@ env:
   kwargs: {}
 
 agent:
-  lr: 0.1
   kwargs:
+    lr: 0.1
     gamma: 0.9

--- a/linear/train_linear_prediction.py
+++ b/linear/train_linear_prediction.py
@@ -91,7 +91,7 @@ def _initialize_agent(cfg: DictConfig, environment) -> object:
 
     # ==
     # Initialize with config parameters
-    agentCls = globals()[cfg.agent.cls_string]  # hacky class
+    agentCls = globals()[cfg.agent.cls_string]  # hacky class init
     agent_kwargs = OmegaConf.to_container(cfg.agent.kwargs)  # convert to dict
     agent_kwargs['seed'] = cfg.training.seed
 

--- a/misc/concat_csvs.sh
+++ b/misc/concat_csvs.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# ============================================================================
+# Vertically concatenate a list of .csv files.
+# Assumes:
+#   - All files have the same header at the first line
+#   - All files have no trailing whitespace
+# ============================================================================
+set -e
+
+# Get list of input arguments
+IN_ARG="$@"
+
+# ==
+# Iterate over all files with counter
+i=0
+for filepath in $IN_ARG; do
+  # ==
+  # (For first file) Save header
+  if [ $i == 0 ]; then
+    awk 'NR == 1' $filepath
+  fi
+
+  # ==
+  # (For all files) Save non header
+  awk 'NR != 1' $filepath
+
+  # Increment counter
+  i=$((i+1));
+done


### PR DESCRIPTION
`linear/train_linear_prediction.py`
- Added `run_experiments` method, which wraps over the previous `run_single_linear_experiment` method 
- Given `config.yaml` containing lists of parameters, takes a cartesian product over (i.e. get all possible combinations of the lists). Works recursively with the hierarchical config
- Then run each combination individually via `run_single_linear_experiment` to output to a single log file 

`linear/conf/config.yaml`
- Bug fix, moved `agent.lr` to `agent.kwargs.lr`
- Previously `lr` was not initialized in the agents during parameter sweep, now fixed

`linear/arg-job_train_hydra.script`
- Updated to reflect the above changes