### PR TITLE
NN incremental v2: LSF AC(lambda) based on MinAtar

### DIFF
--- a/incremental_nonlinear/algos/ac_lambda.py
+++ b/incremental_nonlinear/algos/ac_lambda.py
@@ -169,7 +169,7 @@ class ACLambda:
                 self.msgrads[name] /
                 (1 - self.grad_rms_gamma ** (time_step + 1))
                 + self.grad_rms_eps
-            ) 
+            )
 
             # Update model parameters
             self.model.state_dict()[name].copy_(

--- a/incremental_nonlinear/algos/ac_lambda.py
+++ b/incremental_nonlinear/algos/ac_lambda.py
@@ -44,11 +44,18 @@ class ACLambda:
         # Network for AC evaluation
         self.model = None
         # Eligibility self.traces are stored here
-        self.traces = []
+        self.traces = None
         # Space allocated to store gradients used in training
-        self.grads = []
+        self.grads = None
         # Running average of mean squared gradient for use in RMSProp
-        self.msgrads = []
+        self.msgrads = None
+
+        # List of allowable parameters to include for eligibility traces
+        self.trace_param_list = [
+            'conv.weight', 'conv.bias', 'fc_hidden.weight', 'fc_hidden.bias',
+            'policy.weight', 'policy.bias',
+            'value.weight', 'value.bias',
+        ]
 
     def initialize(self, env, device):
         """Initialize agent"""
@@ -61,24 +68,22 @@ class ACLambda:
             **self.model_kwargs,
         ).to(device)
 
-        # List of parameter names to add eligibility traces to
-        trace_param_list = [
-            'conv.weight', 'conv.bias', 'fc_hidden.weight', 'fc_hidden.bias',
-            'policy.weight', 'policy.bias',
-            'value.weight', 'value.bias',  # 'sf_fn.weight', 'sf_fn_bias',
-        ]
+        self.traces = {}
+        self.grads = {}
+        self.msgrads = {}
 
-        for name, params in self.model.named_parameters():
-            if name not in trace_param_list:
-                continue
-            self.traces.append(torch.zeros(
-                params.size(), dtype=torch.float32, device=device)
-            )
-            self.grads.append(torch.zeros(
-                params.size(), dtype=torch.float32, device=device)
-            )
-            self.msgrads.append(torch.zeros(
-                params.size(), dtype=torch.float32, device=device)
+        for name, param in self.model.named_parameters():
+            if name in self.trace_param_list:
+                self.traces[name] = torch.zeros(
+                    param.size(), dtype=torch.float32, device=device
+                )
+
+                self.grads[name] = torch.zeros(
+                    param.size(), dtype=torch.float32, device=device
+                )
+
+            self.msgrads[name] = torch.zeros(
+                param.size(), dtype=torch.float32, device=device
             )
 
         print(self.model)  # TODO delete?
@@ -95,45 +100,32 @@ class ACLambda:
 
         pi, V_curr = self.model(state)
 
-        # Compute the targets
-        # NOTE: i think this is basically like a sum of the losses used to compute the
-        #       gradients
+        # Compute targets
         trace_potential = V_curr + 0.5 * torch.log(pi[0, action] + self.min_denom)
         entropy = -torch.sum(torch.log(pi + self.min_denom) * pi)
 
-        # Save the value + policy loss gradient
+        # Gradients to be combined with elig traces
         self.model.zero_grad()
         trace_potential.backward(retain_graph=True)
-        with torch.no_grad():
-            for param, grad in zip(self.model.parameters(), self.grads):
-                grad.data.copy_(param.grad)
+        self.store_current_trace_grads()
 
         # Update parameters except for on the first observation
         if last_state is not None:
+            non_trace_loss = - self.entropy_beta * entropy
             self.model.zero_grad()
-            entropy.backward()
+            non_trace_loss.backward()
+
             with torch.no_grad():
                 # TD error
                 V_last = self.model(last_state)[1]
-                delta = self.discount_gamma * (0 if is_terminal else V_curr) + reward - V_last
+                delta = (self.discount_gamma * (0 if is_terminal else V_curr)
+                         + reward - V_last)
 
-                # Update uses RMSProp with initialization debiasing
-                for param, trace, ms_grad in zip(self.model.parameters(),
-                                                 self.traces,
-                                                 self.msgrads):
-                    grad = trace * delta[0] + self.entropy_beta * param.grad
-                    ms_grad.copy_(self.grad_rms_gamma * ms_grad + (1 - self.grad_rms_gamma) * grad * grad)
-                    # Param updates
-                    param.copy_(
-                        param + self.lr_alpha * grad / (torch.sqrt(
-                            ms_grad / (1 - self.grad_rms_gamma ** (time_step + 1)) + self.grad_rms_eps
-                        ))
-                    )
+                # Update
+                self.parameter_step(delta, time_step)
 
         # Accumulating trace (Always update trace)
-        with torch.no_grad():
-            for grad, trace in zip(self.grads, self.traces):
-                trace.copy_(self.trace_lambda * self.discount_gamma * trace + grad)
+        self.accumulate_eligibility_traces()
 
         # ==
         # Construct dict
@@ -146,13 +138,74 @@ class ACLambda:
 
         return out_dict
 
-    def clear_eligibility_traces(self):
+    def parameter_step(self, trace_delta, time_step) -> None:
+        """
+        One step of parameter update with eligibility traces and RMSProp
+        with initialization debiasing
+        :param trace_delta: torch.tensor of the delta (error) to be
+                            combined with the elig trace
+        :param time_step: number of optim steps for initialization debiasing
+        :return:
+        """
+
+        # Iterate over all model parameters
+        for name, param in self.model.named_parameters():
+            # Compute the trace for the current set of parameters
+            trace = 0.0
+            if name in self.traces:
+                trace = self.traces[name]
+
+            # Compute the parameter delta
+            grad = (trace * trace_delta[0]) + (-param.grad)
+
+            # Update the mean squared grad (for RMSProp)
+            self.msgrads[name].data.copy_(
+                self.grad_rms_gamma * self.msgrads[name]
+                + ((1 - self.grad_rms_gamma) * grad * grad)
+            )
+
+            # Update RMSprop adaptive denominator
+            delta_denom = torch.sqrt(
+                self.msgrads[name] /
+                (1 - self.grad_rms_gamma ** (time_step + 1))
+                + self.grad_rms_eps
+            ) 
+
+            # Update model parameters
+            self.model.state_dict()[name].copy_(
+                param + self.lr_alpha * (grad / delta_denom)
+            )
+
+    def store_current_trace_grads(self) -> None:
+        """
+        Helper method, saves the current gradients on the parameters
+        of self.model that require eligibility traces to self.grads
+        :return: None
+        """
+        with torch.no_grad():
+            for name, param in self.model.named_parameters():
+                if name in self.grads:
+                    self.grads[name].data.copy_(param.grad)
+
+    def accumulate_eligibility_traces(self) -> None:
+        """
+        Accumulate the gradients in self.grads in self.traces
+        :return:
+        """
+        with torch.no_grad():
+            for name in self.traces:
+                self.traces[name].data.copy_(
+                    self.trace_lambda * self.discount_gamma * self.traces[name]
+                    + self.grads[name]
+                )
+
+    def clear_eligibility_traces(self) -> None:
         """
         Called to clear the elig traces at the end of an episode
         :return: None
         """
-        for trace in self.traces:
-            trace.zero_()
+        for name in self.traces:
+            self.traces[name].zero_()
 
 
 if __name__ == '__main__':

--- a/incremental_nonlinear/algos/lsf_ac_lambda.py
+++ b/incremental_nonlinear/algos/lsf_ac_lambda.py
@@ -1,0 +1,156 @@
+# ============================================================================
+# Original Authors:
+# Kenny Young (kjyoung@ualberta.ca)
+# Tian Tian (ttian@ualberta.ca)
+#
+# References used for this implementation:
+#   https://pytorch.org/docs/stable/nn.html#
+#   https://pytorch.org/docs/stable/torch.html
+#   https://pytorch.org/tutorials/intermediate/reinforcement_q_learning.html
+# ============================================================================
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as f
+
+from algos.ac_lambda import ACLambda
+
+
+class LSF_ACLambda(ACLambda):
+    """
+    Incremental AC lambda agent
+    """
+
+    def __init__(self, ModelCls, model_kwargs,
+                 discount_gamma=0.99,
+                 lr_alpha=0.00048828125,
+                 trace_lambda=0.8,
+                 entropy_beta=0.01,
+                 grad_rms_gamma=0.999,
+                 grad_rms_eps=0.0001,
+                 min_denom=0.0001,
+                 sf_lambda=0.0,
+                 ):
+        # TODO: put more things as arguments
+        super().__init__(
+            ModelCls, model_kwargs, discount_gamma=discount_gamma,
+            lr_alpha=lr_alpha, trace_lambda=trace_lambda,
+            entropy_beta=entropy_beta, grad_rms_gamma=grad_rms_gamma,
+            grad_rms_eps=grad_rms_eps, min_denom=min_denom,
+        )
+        self.sf_lambda = sf_lambda
+
+    def optimize_agent(self, sample, time_step):
+
+        # states, next_states: (1, in_channel, 10, 10) - inline with pytorch NCHW format
+        # actions, rewards, is_terminal: (1, 1)
+        last_state = sample.last_state
+        state = sample.state
+        action = sample.action
+        reward = sample.reward
+        is_terminal = sample.is_terminal
+
+        model_out_tup = self.model.compute_pi_v_sf_r_lsfv(state,
+                                                          self.sf_lambda)
+        pi, V_curr, sf_curr, r_curr, lsf_V_curr, phi_curr = model_out_tup
+
+        # Compute the targets
+        # NOTE: i think this is basically like a sum of the losses used to compute the
+        #       gradients
+        trace_potential = (
+                V_curr  # value grad
+                + (0.5 * torch.log(pi[0, action] + self.min_denom))  # pol grad
+        )
+
+        # Save the value + policy loss + sf gradient (for traces)
+        self.model.zero_grad()
+        trace_potential.backward(retain_graph=True)
+        with torch.no_grad():
+            for param, grad in zip(self.model.parameters(), self.grads):
+                # TODO check and confirm this is working
+                grad.data.copy_(param.grad)
+
+        #
+        entropy = -torch.sum(torch.log(pi + self.min_denom) * pi)
+
+        # Update parameters except for on the first observation
+        if last_state is not None:
+
+            # SF loss
+            phi_last = self.model.compute_phi(last_state)
+            sf_last = self.model.sf_fn(phi_last)  # (1, d)
+            sf_target = phi_last.detach().clone() + (
+                    (self.sf_lambda * self.discount_gamma) * sf_curr.detach().clone()
+            )  # TODO NOTE do I need to clone after detach?
+            sf_loss = torch.mean(0.5 * (sf_target - sf_last) ** 2)
+
+            # Reward loss  # TODO check if dimension is correct
+            rew_last = self.model.reward_layer(phi_last)[0]
+            rew_loss = 0.5 * (reward - rew_last) ** 2
+
+            # Inverse non-trace losses to optimize
+            non_trace_inv_loss = - (
+                    (0.5 * sf_loss) + (0.5 * rew_loss)
+                    - (self.entropy_beta * entropy)
+            )  # TODO add customizable coefficients
+            self.model.zero_grad()
+            non_trace_inv_loss.backward()
+
+            with torch.no_grad():
+                # ==
+                # Errors
+
+                # Value TD error
+                V_last = self.model(last_state)[1]
+                v_target = (self.discount_gamma *
+                            (0 if is_terminal else lsf_V_curr) + reward)
+                v_delta = v_target - V_last
+
+                # ==
+                # Update uses RMSProp with initialization debiasing
+                for param, trace, ms_grad in zip(self.model.parameters(),
+                                                 self.traces,
+                                                 self.msgrads):
+                    # elig trace deltas + other deltas
+                    grad = trace * v_delta[0] + param.grad
+
+                    # TODO NOTE: do a multiplication of trace * param.grad instead??
+
+                    # RMSProp and update
+                    ms_grad.copy_(self.grad_rms_gamma * ms_grad + (1 - self.grad_rms_gamma) * grad * grad)
+                    # Param updates
+                    param.copy_(
+                        param + self.lr_alpha * grad / (torch.sqrt(
+                            ms_grad / (1 - self.grad_rms_gamma ** (time_step + 1)) + self.grad_rms_eps
+                        ))
+                    )
+
+        # Accumulating trace (Always update trace)
+        with torch.no_grad():
+            for grad, trace in zip(self.grads, self.traces):
+                trace.copy_(self.trace_lambda * self.discount_gamma * trace + grad)
+
+        # ==
+        # Construct dict
+        out_dict = None
+        # TODO log the average trace magnitude
+        if last_state is not None:
+            out_dict = {
+                'value_loss': v_delta.item() ** 2,
+                'sf_loss': sf_loss.item(),
+                'reward_loss': rew_loss.item(),
+            }
+
+        return out_dict
+
+    def clear_eligibility_traces(self):
+        """
+        Called to clear the elig traces at the end of an episode
+        :return: None
+        """
+        for trace in self.traces:
+            trace.zero_()
+
+
+if __name__ == '__main__':
+    pass

--- a/incremental_nonlinear/arg-job_train_hydra.script
+++ b/incremental_nonlinear/arg-job_train_hydra.script
@@ -25,16 +25,16 @@ source $HOME/venvs/rlpyt/bin/activate
 python -u train_incremental.py --multirun \
     hydra.run.dir=$sweep_parent_dir \
     hydra.sweep.dir=$sweep_parent_dir \
-    runner.n_steps=15e4 \
+    runner.n_steps=1e5 \
     runner.kwargs.log_interval_episodes=100 \
     env.kwargs.env_name='breakout' \
     algo=lsf_ac_lambda \
     algo.kwargs.lr_alpha=0.00048828125 \
-    algo.kwargs.trace_lambda=0.0 \
-    algo.kwargs.sf_lambda=0.0,0.2,0.5,1.0 \
+    algo.kwargs.trace_lambda=0.0,0.5,0.95 \
+    algo.kwargs.sf_lambda=0.0,0.5,0.95 \
     model=lsf_ac_network \
     model.kwargs.fc_sizes=128 \
-    model.kwargs.sf_hidden_sizes=null,[128],[128,128] \
+    model.kwargs.sf_hidden_sizes=[256],[256,256] \
     training.seed=2,4 \
 
 # (4) Copy things over to scratch?

--- a/incremental_nonlinear/arg-job_train_hydra.script
+++ b/incremental_nonlinear/arg-job_train_hydra.script
@@ -25,14 +25,16 @@ source $HOME/venvs/rlpyt/bin/activate
 python -u train_incremental.py --multirun \
     hydra.run.dir=$sweep_parent_dir \
     hydra.sweep.dir=$sweep_parent_dir \
-    runner.n_steps=1e6 \
+    runner.n_steps=15e4 \
     runner.kwargs.log_interval_episodes=100 \
     env.kwargs.env_name='breakout' \
-    algo.cls_string='ACLambda' \
+    algo=lsf_ac_lambda \
     algo.kwargs.lr_alpha=0.00048828125 \
-    algo.kwargs.trace_lambda=0.0,0.8 \
-    model.cls_string='ACNetwork' \
+    algo.kwargs.trace_lambda=0.0 \
+    algo.kwargs.sf_lambda=0.0,0.2,0.5,1.0 \
+    model=lsf_ac_network \
     model.kwargs.fc_sizes=128 \
+    model.kwargs.sf_hidden_sizes=null,[128],[128,128] \
     training.seed=2,4 \
 
 # (4) Copy things over to scratch?

--- a/incremental_nonlinear/conf/algo/lsf_ac_lambda.yaml
+++ b/incremental_nonlinear/conf/algo/lsf_ac_lambda.yaml
@@ -1,0 +1,11 @@
+# @package _group_
+cls_string: 'LSF_ACLambda'
+kwargs:
+  discount_gamma: 0.99
+  lr_alpha: 0.00048828125
+  trace_lambda: 0.8
+  entropy_beta: 0.01
+  grad_rms_gamma: 0.999
+  grad_rms_eps: 0.0001
+  min_denom: 0.0001
+  sf_lambda: 0.0

--- a/incremental_nonlinear/conf/model/lsf_ac_network.yaml
+++ b/incremental_nonlinear/conf/model/lsf_ac_network.yaml
@@ -1,0 +1,5 @@
+# @package _group_
+cls_string: 'LSF_ACNetwork'
+kwargs:
+  fc_sizes: 128
+  sf_hidden_sizes: null  #[128, 128]

--- a/incremental_nonlinear/models/lsf_ac_network.py
+++ b/incremental_nonlinear/models/lsf_ac_network.py
@@ -1,0 +1,128 @@
+##############################################################################
+# ACNetwork
+#
+# Original Authors:
+# Kenny Young (kjyoung@ualberta.ca)
+# Tian Tian (ttian@ualberta.ca)
+#
+# References used for this implementation:
+#   https://pytorch.org/docs/stable/nn.html#
+#   https://pytorch.org/docs/stable/torch.html
+#   https://pytorch.org/tutorials/intermediate/reinforcement_q_learning.html
+#
+# Anthony G. Chen
+##############################################################################
+
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as f
+
+from models.ac_network import ACNetwork
+
+# ==
+# activation functions
+dSiLU = lambda x: torch.sigmoid(x) * (1 + x * (1 - torch.sigmoid(x)))
+SiLU = lambda x: x * torch.sigmoid(x)
+
+
+class nn_SiLU(nn.Module):
+    def __init__(self):
+        super(nn_SiLU, self).__init__()
+    def forward(self, x):
+        return SiLU(x)
+
+
+# ==
+# Network class
+class LSF_ACNetwork(ACNetwork):
+    def __init__(
+            self,
+            in_channels, num_actions,  # TODO use image_shape, output_size??
+            fc_sizes=128,
+            sf_hidden_sizes=None,
+            detach_sf_grad=False,
+    ):
+        super().__init__(in_channels, num_actions, fc_sizes)
+
+        # ==
+        # Add the sf layers
+
+        # Value layer without bias
+        self.value = nn.Linear(in_features=self.fc_sizes,
+                               out_features=1, bias=False)
+
+        # Initialize reward function layer
+        self.reward_layer = torch.nn.Linear(self.fc_sizes, 1, bias=False)
+
+        # Initialize the SF function layer(s)
+        if sf_hidden_sizes is None or len(sf_hidden_sizes) == 0:
+            self.sf_fn = nn.Linear(self.fc_sizes, self.fc_sizes, bias=False)
+            self.sf_fn.weight.data.copy_(torch.eye(self.fc_sizes))
+        else:
+            sf_fn_layers_list = [
+                nn.Linear(self.fc_sizes, sf_hidden_sizes[0]),
+                nn_SiLU(),
+            ]
+            for i in range(1, len(sf_hidden_sizes)):
+                sf_fn_layers_list.extend([
+                    nn.Linear(sf_hidden_sizes[i - 1], sf_hidden_sizes[i]),
+                    nn_SiLU(),
+                ])
+            sf_fn_layers_list.extend([
+                nn.Linear(sf_hidden_sizes[-1], self.fc_sizes),
+            ])
+            self.sf_fn = nn.Sequential(*sf_fn_layers_list)
+
+        # Other attributes
+        self.detach_sf_grad = detach_sf_grad
+
+    def compute_phi(self, x):
+        """Feature extractor"""
+        # Output from the first conv with sigmoid linear activation
+        x = SiLU(self.conv(x))
+        # Output from the final hidden layer with derivative of sigmoid linear activation
+        x = dSiLU(self.fc_hidden(x.view(x.size(0), -1)))
+        return x
+
+    def forward(self, x):
+        # Feature extract
+        x = self.compute_phi(x)
+
+        # Return policy and value outputs
+        return f.softmax(self.policy(x), dim=1), self.value(x)
+
+    def compute_pi_v_sf_r_lsfv(self, x, sf_lambda):
+        # Feature extract
+        x = self.compute_phi(x)
+
+        # Policy distribution and value outputs
+        pi = f.softmax(self.policy(x), dim=1)
+        v = self.value(x)
+
+        # Successor feature
+        if self.detach_sf_grad:
+            sf = self.sf_fn(x.detach().clone())
+        else:
+            sf = self.sf_fn(x)
+
+        # Reward
+        r = self.reward_layer(x)
+
+        # ==
+        # The LSV bootstrap target
+        with torch.no_grad():
+            cp_sf = sf.detach().clone()
+            sf_v = self.value(cp_sf)
+            sf_r = self.reward_layer(cp_sf)
+
+            lsf_v = ((1 - sf_lambda) * sf_v) + (sf_lambda * sf_r)
+            lsf_v = lsf_v.detach().clone()
+
+        return pi, v, sf, r, lsf_v, x
+
+
+if __name__ == '__main__':
+    model = ACNetwork(3, 4)
+    print(model)
+    pass


### PR DESCRIPTION
Made the original AC(lambda) code (`incremental_nonlinear/algos/ac_lambda.py`) more modular to better make sense of the parameter updates which combine both eligibility traces and RMSProp.

Built LSF on top of above AC(lambda) code: `incremental_nonlinear/algos/lsf_ac_lambda.py` and `incremental_nonlinear/models/lsf_ac_network.py`